### PR TITLE
Routing and Status Handler

### DIFF
--- a/client/src/app/home/home.component.ts
+++ b/client/src/app/home/home.component.ts
@@ -45,28 +45,41 @@ export class HomeComponent implements OnInit, OnDestroy {
     }
 
     async getUserInfo() {
-        this.userInfoService.getUserInfo().subscribe((resp: any) => {
-            if(resp.status === 401) {
-                console.log('Error: Bad Authentication');
-                return;
-            }
+        // this.userInfoService.getUserInfo().subscribe(
+        // (resp: any) => {
+        //     if(resp.status === 401) {
+        //         console.log('Error: Bad Authentication');
+        //         return;
+        //     }
 
-            this.username = resp.body.display_name;
-            this.url = resp.body.external_urls.spotify;
+        //     this.username = resp.body.display_name;
+        //     this.url = resp.body.external_urls.spotify;
+        // }
+        // );
+
+        this.userInfoService.getUserInfo().subscribe({
+            next: (resp: any) => {
+                this.username = resp.body.display_name;
+                this.url = resp.body.external_urls.spotify;
+            },
+            error: (resp: any) => {
+                console.log(resp.error);
+            }
         });
     }
 
     async getCurrentTrack() {
-        this.userInfoService.getTrackInfo().subscribe((resp: any) => {
-            if(resp.status === 204) {
+        this.userInfoService.getTrackInfo().subscribe({
+            next: (resp: any) => {
+                this.isPlaying = true;
+                this.songTitle = resp.body.item.name;
+                this.artist = resp.body.item.artists.map((artist: any) => artist.name).join(', ');
+                this.imgUrl = resp.body.item.album.images[0].url;
+            },
+            error: (resp: any) => {
                 this.isPlaying = false;
-                return;
+                console.log(resp.error);
             }
-
-            this.isPlaying = true;
-            this.songTitle = resp.body.item.name;
-            this.artist = resp.body.item.artists.map((artist: any) => artist.name).join(', ');
-            this.imgUrl = resp.body.item.album.images[0].url;
         });
     }
 

--- a/client/src/app/home/home.component.ts
+++ b/client/src/app/home/home.component.ts
@@ -59,6 +59,11 @@ export class HomeComponent implements OnInit, OnDestroy {
     async getCurrentTrack() {
         this.userInfoService.getTrackInfo().subscribe({
             next: (resp: any) => {
+                if(resp.status === 204) {
+                    this.isPlaying = false;
+                    return;
+                }
+
                 this.isPlaying = true;
                 this.songTitle = resp.body.item.name;
                 this.artist = resp.body.item.artists.map((artist: any) => artist.name).join(', ');

--- a/client/src/app/home/home.component.ts
+++ b/client/src/app/home/home.component.ts
@@ -45,18 +45,6 @@ export class HomeComponent implements OnInit, OnDestroy {
     }
 
     async getUserInfo() {
-        // this.userInfoService.getUserInfo().subscribe(
-        // (resp: any) => {
-        //     if(resp.status === 401) {
-        //         console.log('Error: Bad Authentication');
-        //         return;
-        //     }
-
-        //     this.username = resp.body.display_name;
-        //     this.url = resp.body.external_urls.spotify;
-        // }
-        // );
-
         this.userInfoService.getUserInfo().subscribe({
             next: (resp: any) => {
                 this.username = resp.body.display_name;

--- a/client/src/app/services/api.service.ts
+++ b/client/src/app/services/api.service.ts
@@ -8,6 +8,6 @@ export class ApiService {
     protected http: HttpClient = inject(HttpClient);
 
     protected apiUrl: string = 'http://localhost:4000/api';
-    protected authUrl: string = 'http://localhost:4000/auth';
+    protected apiAuthUrl: string = 'http://localhost:4000/auth';
     protected requestOptions : any = { observe: 'response', withCredentials: true };
 }

--- a/client/src/app/services/api.service.ts
+++ b/client/src/app/services/api.service.ts
@@ -7,6 +7,7 @@ import { HttpClient } from '@angular/common/http';
 export class ApiService {
     protected http: HttpClient = inject(HttpClient);
 
-    protected apiUrl: string = 'http://localhost:4000';
+    protected apiUrl: string = 'http://localhost:4000/api';
+    protected authUrl: string = 'http://localhost:4000/auth';
     protected requestOptions : any = { observe: 'response', withCredentials: true };
 }

--- a/client/src/app/services/auth.service.ts
+++ b/client/src/app/services/auth.service.ts
@@ -6,7 +6,7 @@ import { ApiService } from './api.service';
 })
 export class AuthService extends ApiService {
     hasAuthToken() {
-        return this.http.get(this.apiUrl + '/hasAuthToken', this.requestOptions);
+        return this.http.get(this.authUrl + '/hasAuthToken', this.requestOptions);
     }
 
     hasError() {
@@ -20,7 +20,7 @@ export class AuthService extends ApiService {
     }
 
     getOAuthURL() {
-        return this.http.get(this.apiUrl + '/login');
+        return this.http.get(this.authUrl + '/login');
     }
 
     authorizeWithParams() {
@@ -37,13 +37,13 @@ export class AuthService extends ApiService {
 
             console.log(code, state);
 
-            return this.http.get(this.apiUrl + '/getAuthInfo?' + authParams.toString(), this.requestOptions);
+            return this.http.get(this.authUrl + '/getAuthInfo?' + authParams.toString(), this.requestOptions);
         }
 
         return undefined;
     }
 
     logout() {
-        return this.http.get(this.apiUrl + '/logout', this.requestOptions);
+        return this.http.get(this.authUrl + '/logout', this.requestOptions);
     }
 }

--- a/client/src/app/services/auth.service.ts
+++ b/client/src/app/services/auth.service.ts
@@ -6,7 +6,7 @@ import { ApiService } from './api.service';
 })
 export class AuthService extends ApiService {
     hasAuthToken() {
-        return this.http.get(this.authUrl + '/hasAuthToken', this.requestOptions);
+        return this.http.get(this.apiAuthUrl + '/hasAuthToken', this.requestOptions);
     }
 
     hasError() {
@@ -20,7 +20,7 @@ export class AuthService extends ApiService {
     }
 
     getOAuthURL() {
-        return this.http.get(this.authUrl + '/login');
+        return this.http.get(this.apiAuthUrl + '/login');
     }
 
     authorizeWithParams() {
@@ -35,15 +35,13 @@ export class AuthService extends ApiService {
                 state: state
             });
 
-            console.log(code, state);
-
-            return this.http.get(this.authUrl + '/getAuthInfo?' + authParams.toString(), this.requestOptions);
+            return this.http.get(this.apiAuthUrl + '/getAuthInfo?' + authParams.toString(), this.requestOptions);
         }
 
         return undefined;
     }
 
     logout() {
-        return this.http.get(this.authUrl + '/logout', this.requestOptions);
+        return this.http.get(this.apiAuthUrl + '/logout', this.requestOptions);
     }
 }

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1,0 +1,16 @@
+const router = require('express').Router();
+const { SpotifyAPI } = require('../spotify/spotifyApi.js');
+
+router.get('/getUserInfo', async (req, res) => {
+    const userInfo = await SpotifyAPI.Get('/me', req, res);
+
+    res.json(userInfo);
+})
+
+router.get('/getTrack', async (req, res) => {
+    const playerInfo = await SpotifyAPI.Get('/me/player', req, res);
+
+    res.json(playerInfo);
+})
+
+module.exports = router;

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,30 @@
+const router = require('express').Router();
+const { SpotifyAuth } = require('../spotify/spotifyAuth.js');
+
+router.get('/login', async (req, res) => {
+    res.send({ url: await SpotifyAuth.generateSpotifyAuthLink() });
+});
+
+router.get('/refresh', async (req, res) => {
+    await SpotifyAuth.refreshCurrentTokens(req, res);
+
+    res.send("Refreshed your tokens!");
+});
+
+router.get('/logout', (req, res) => {
+    SpotifyAuth.deleteCookieTokens(res);
+
+    res.send({ loggedOut: true });
+})
+
+router.get('/hasAuthToken', (req, res) => {
+    res.json({ hasToken: SpotifyAuth.hasAuthToken(req) });
+});
+
+router.get('/getAuthInfo', async (req, res) => {
+    await SpotifyAuth.getAuthInfo(req, res);
+
+    res.json({ authSuccessful: true });
+});
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -1,9 +1,7 @@
 const express = require("express");
 const cookieParser = require("cookie-parser");
 const cors = require('cors');
-const { SpotifyAuth } = require('./spotify/spotifyAuth.js');
-const { SpotifyAPI } = require('./spotify/spotifyApi.js');
-const { populate } = require("dotenv");
+require("dotenv").config();
 
 const app = express();
 const PORT = process.env.PORT || 4000;
@@ -14,46 +12,11 @@ app.use(cors({
 }))
 app.use(cookieParser());
 
+const authRouter = require('./routes/auth.js');
+const apiRouter = require('./routes/api.js');
 
-app.get('/login', async (req, res) => {
-    res.send({ url: await SpotifyAuth.generateSpotifyAuthLink() });
-});
-
-app.get('/refresh', async (req, res) => {
-    await SpotifyAuth.refreshCurrentTokens(req, res);
-
-    res.send("Refreshed your tokens!");
-});
-
-app.get('/logout', (req, res) => {
-    SpotifyAuth.deleteCookieTokens(res);
-
-    res.send({ loggedOut: true });
-})
-
-app.get('/hasAuthToken', (req, res) => {
-    res.json({ hasToken: SpotifyAuth.hasAuthToken(req) });
-});
-
-app.get('/getAuthInfo', async (req, res) => {
-    await SpotifyAuth.getAuthInfo(req, res);
-
-    res.json({ authSuccessful: true });
-});
-
-
-app.get('/getUserInfo', async (req, res) => {
-    const userInfo = await SpotifyAPI.Get('/me', req, res);
-
-    res.json(userInfo);
-})
-
-app.get('/getTrack', async (req, res) => {
-    const playerInfo = await SpotifyAPI.Get('/me/player', req, res);
-
-    res.json(playerInfo);
-})
-
+app.use('/auth', authRouter);
+app.use('/api', apiRouter);
 
 app.listen(PORT, () => {
     console.log("Server running on http://localhost:" + PORT + "/");

--- a/server/spotify/spotifyApi.js
+++ b/server/spotify/spotifyApi.js
@@ -6,7 +6,6 @@ class SpotifyAPI {
             method: "GET", headers: { Authorization: `Bearer ${req.cookies.authToken}` }
         });
 
-
         return await this.handleResponseStatus(result, res);
     }
 

--- a/server/spotify/spotifyApi.js
+++ b/server/spotify/spotifyApi.js
@@ -6,13 +6,24 @@ class SpotifyAPI {
             method: "GET", headers: { Authorization: `Bearer ${req.cookies.authToken}` }
         });
 
+
+        return await this.handleResponseStatus(result, res);
+    }
+
+    static async handleResponseStatus(result, res) {
         res.status(result.status);
 
         if(result.status === 204) {
             return {};
         }
 
-        return await result.json();
+        const json = await result.json();
+
+        if(result.status >= 400 && result.status <= 429) {
+            return json.error;
+        } 
+
+        return json;
     }
 }
 


### PR DESCRIPTION
I have setup the express router so all auth related requests go to `/auth` and all API related ones go to `/api`. 

I have also setup a status code handler in the SpotifyAPI class, which is used to handle the response/result from the spotify API fetch. 
For example, it sets the status code for our API's response as the same, and decides what to send back as the response body/json to the client (empty for `204`, error message for `4xx`, etc).