### PR TITLE
Lyrics API Fixed

### DIFF
--- a/client/src/app/home/home.component.ts
+++ b/client/src/app/home/home.component.ts
@@ -79,6 +79,8 @@ export class HomeComponent implements OnInit, OnDestroy {
 
                 this.isPlayerActive = true;
 
+                console.log(resp.body.item);
+
                 this.currentSongImgUrl = resp.body.item.album.images[0].url;
                 this.currentSongTitle = resp.body.item.name;
                 this.currentSongUrl = resp.body.item.external_urls.spotify;
@@ -95,7 +97,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 
                     this.loadingLyrics = true;
 
-                    this.userInfoService.getLyrics(resp.body.item.artists.map((artist: any) => artist.name), resp.body.item.name).subscribe({
+                    this.userInfoService.getLyrics(resp.body.item.artists.map((artist: any) => artist.name), resp.body.item.name, resp.body.item.external_ids.isrc).subscribe({
                         next: (resp: any) => {
                             this.loadingLyrics = false;
 

--- a/client/src/app/home/home.component.ts
+++ b/client/src/app/home/home.component.ts
@@ -79,8 +79,6 @@ export class HomeComponent implements OnInit, OnDestroy {
 
                 this.isPlayerActive = true;
 
-                console.log(resp.body.item);
-
                 this.currentSongImgUrl = resp.body.item.album.images[0].url;
                 this.currentSongTitle = resp.body.item.name;
                 this.currentSongUrl = resp.body.item.external_urls.spotify;
@@ -97,7 +95,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 
                     this.loadingLyrics = true;
 
-                    this.userInfoService.getLyrics(resp.body.item.artists.map((artist: any) => artist.name), resp.body.item.name, resp.body.item.external_ids.isrc).subscribe({
+                    this.userInfoService.getLyrics(resp.body.item.external_ids.isrc).subscribe({
                         next: (resp: any) => {
                             this.loadingLyrics = false;
 

--- a/client/src/app/services/user-info.service.ts
+++ b/client/src/app/services/user-info.service.ts
@@ -13,10 +13,10 @@ export class UserInfoService extends ApiService {
         return this.http.get(this.apiUrl + '/getTrack', this.requestOptions);
     }
 
-    getLyrics(artists: string[], title: string, isrc: string) {
-        const params = new URLSearchParams(artists.map(artist => ['artists', artist]));
-        params.append('title', title);
-        params.append('isrc', isrc);
+    getLyrics(isrc: string) {
+        const params = new URLSearchParams({
+            isrc: isrc,
+        });
 
         return this.http.get(this.apiUrl + '/getLyrics?' + params.toString(), this.requestOptions);
     }

--- a/client/src/app/services/user-info.service.ts
+++ b/client/src/app/services/user-info.service.ts
@@ -13,9 +13,10 @@ export class UserInfoService extends ApiService {
         return this.http.get(this.apiUrl + '/getTrack', this.requestOptions);
     }
 
-    getLyrics(artists: string[], title : string) {
+    getLyrics(artists: string[], title: string, isrc: string) {
         const params = new URLSearchParams(artists.map(artist => ['artists', artist]));
         params.append('title', title);
+        params.append('isrc', isrc);
 
         return this.http.get(this.apiUrl + '/getLyrics?' + params.toString(), this.requestOptions);
     }

--- a/server/lyrics/geniusApi.js
+++ b/server/lyrics/geniusApi.js
@@ -9,20 +9,16 @@ class GeniusAPI {
 
     static async getLyrics(artists, title) {
         try {
-            // title = cleanTitleForSearch(title);
-
-            const hasMultipleArtists = Array.isArray(artists);
-
-            if(!hasMultipleArtists) {
-                return await this.getBestLyrics([artists], title);
-            }
-
             for(let i = 0; i < artists.length; i++) {
                 const result = await this.getBestLyrics([artists[i]], title);
 
                 if(result !== null) {
                     return result;
                 }
+            }
+
+            if(artists.length === 1) {
+                return null;
             }
 
             return await this.getBestLyrics(artists, title);

--- a/server/lyrics/musixmatchApi.js
+++ b/server/lyrics/musixmatchApi.js
@@ -1,31 +1,27 @@
 const musixMatchToken = process.env.MUSIX_MATCH_TOKEN;
 
+const DEBUG_LYRICS = false;
+
 class MusixmatchAPI {
     static musixmatchApiUrl = 'https://api.musixmatch.com/ws/1.1'
 
-    static async getLyrics(artists, title) {
+    static async getLyrics(isrc) {
         try {
-            const searches = await this.searchForSong(title);
+            const song = await this.getTrack(isrc);
 
-            if(searches.length === 0){
+            if(song === null) {
                 return null;
             }
 
-            if(!Array.isArray(artists)) {
-                artists = [artists];
-            }
+            const lyrics = await this.getLyricsByID(song.track_id);
 
-            let bestSearch = this.getBestSearch(searches, artists, title);
-
-            if(bestSearch === null || bestSearch.has_lyrics !== 1) {
+            if(lyrics === null) {
                 return null;
             }
-
-            const lyrics = await this.getLyricsByID(bestSearch.track_id);
 
             return {
                 provider: 'musixmatch',
-                url: bestSearch.track_share_url,
+                url: song.track_share_url,
                 lyrics: lyrics.lyrics_body,
             };
         } catch (err) {
@@ -46,6 +42,10 @@ class MusixmatchAPI {
             });
 
             const json = await result.json();
+
+            if(json.message.header.status_code === 404) {
+                return null;
+            }
             
             return json.message.body.lyrics;
         } catch (err) {
@@ -54,95 +54,27 @@ class MusixmatchAPI {
         }
     }
 
-    static async searchForSong(title) {
+    static async getTrack(isrc) {
         try {
             const params = new URLSearchParams({
                 apikey: musixMatchToken,
-                q_track: title,
-                page_size: 10,
-                page: 1,
-                s_track_rating: 'desc',
+                track_isrc: isrc,
             });
 
-            const result = await fetch(this.musixmatchApiUrl + '/track.search?' + params.toString(), {
+            const result = await fetch(this.musixmatchApiUrl + '/track.get?' + params.toString(), {
                 method: 'GET',
             });
 
             const json = await result.json();
-            
-            return json.message.body.track_list;
+
+            return json.message.body.track;
         } catch (err) {
             console.log(err);
-            return [];
+            return null;
         }
     }
 
-    static getBestSearch(searches, reqArtists, reqTitle) {
-        let i = 1;
-
-        const simplifiedReqTitle = simplifyText(reqTitle);
-
-        for(let item of searches) {
-            let hasArtists = false;
-            
-            for(let reqArtist of reqArtists) {
-                if(compareText(simplifyText(item.track.artist_name), simplifyText(reqArtist))) {
-                    hasArtists = true;
-                    break;
-                }
-            }
-
-            if(!hasArtists) {
-                continue;
-            }
-            
-            const simplifiedTitle = simplifyText(item.track.track_name);
-
-            let titleIncludes = compareText(simplifiedTitle, simplifiedReqTitle);
-
-            if(titleIncludes) {
-                return item.track;
-            }
-        }
-
-        for(let item of searches) {
-            const simplifiedTitle = simplifyText(item.track.track_name);
-
-            let isTitle = simplifiedTitle === simplifiedReqTitle;
-
-            if(isTitle) {
-                return item.track;
-            }
-        }
-
-        for(let item of searches) {
-            for(let reqArtist of reqArtists) {
-                if(simplifyText(item.track.artist_name) === simplifyText(reqArtist)) {
-                    return item.track;
-                }
-            }
-        }
-
-        return null;
-    }
 };
-
-function compareText(textOne, textTwo) {
-    return textOne.includes(textTwo) || textTwo.includes(textOne);
-}
-
-function simplifyText(text) {
-    return text
-        .toLowerCase()
-        .replaceAll(' ', '')
-        .replaceAll('’', "'")
-        .replace(/[–—]/g, '-')
-        .replaceAll('˃', '>')
-        .replaceAll('˂', '<')
-        .replaceAll('…', '...')
-        .replaceAll(',', '')
-        .normalize('NFC');
-}
 
 module.exports = {
     MusixmatchAPI,

--- a/server/lyrics/musixmatchApi.js
+++ b/server/lyrics/musixmatchApi.js
@@ -1,7 +1,5 @@
 const musixMatchToken = process.env.MUSIX_MATCH_TOKEN;
 
-const DEBUG_LYRICS = false;
-
 class MusixmatchAPI {
     static musixmatchApiUrl = 'https://api.musixmatch.com/ws/1.1'
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -16,21 +16,12 @@ router.get('/getTrack', async (req, res) => {
 });
 
 router.get('/getLyrics', async (req, res) => {
-    const params = new URLSearchParams({
-        type: 'track',
-        q: `isrc:${req.query.isrc}`,
-    })
+    const currentTrack = await SpotifyAPI.getSongByISRC(req.query.isrc, req, res);
 
-    let currentTrack = await SpotifyAPI.Get(`/search?${params.toString()}`, req, res);
-    currentTrack = currentTrack.tracks.items[0];
-
-    const artists = currentTrack.artists.map((artist) => artist.name);
-    const title = currentTrack.name;
-
-    let lyrics = await GeniusAPI.getLyrics(artists, title);
+    let lyrics = await GeniusAPI.getLyrics(currentTrack.artists, currentTrack.title);
 
     if(lyrics === null) {
-        lyrics = await MusixmatchAPI.getLyrics(artists, title);
+        lyrics = await MusixmatchAPI.getLyrics(currentTrack.artists, currentTrack.title);
     }
 
     res.json(lyrics);

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -16,10 +16,21 @@ router.get('/getTrack', async (req, res) => {
 });
 
 router.get('/getLyrics', async (req, res) => {
-    let lyrics = await GeniusAPI.getLyrics(req.query.artists, req.query.title);
+    const params = new URLSearchParams({
+        type: 'track',
+        q: `isrc:${req.query.isrc}`,
+    })
+
+    let currentTrack = await SpotifyAPI.Get(`/search?${params.toString()}`, req, res);
+    currentTrack = currentTrack.tracks.items[0];
+
+    const artists = currentTrack.artists.map((artist) => artist.name);
+    const title = currentTrack.name;
+
+    let lyrics = await GeniusAPI.getLyrics(artists, title);
 
     if(lyrics === null) {
-        lyrics = await MusixmatchAPI.getLyrics(req.query.artists, req.query.title);
+        lyrics = await MusixmatchAPI.getLyrics(artists, title);
     }
 
     res.json(lyrics);

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -21,7 +21,7 @@ router.get('/getLyrics', async (req, res) => {
     let lyrics = await GeniusAPI.getLyrics(currentTrack.artists, currentTrack.title);
 
     if(lyrics === null) {
-        lyrics = await MusixmatchAPI.getLyrics(currentTrack.artists, currentTrack.title);
+        lyrics = await MusixmatchAPI.getLyrics(req.query.isrc);
     }
 
     res.json(lyrics);

--- a/server/spotify/spotifyApi.js
+++ b/server/spotify/spotifyApi.js
@@ -15,6 +15,24 @@ class SpotifyAPI {
         }
     }
 
+    static async getSongByISRC(isrc, req, res) {
+        const params = new URLSearchParams({
+            type: 'track',
+            q: `isrc:${isrc}`,
+        });
+    
+        let currentTrack = await SpotifyAPI.Get(`/search?${params.toString()}`, req, res);
+        currentTrack = currentTrack.tracks.items[0];
+
+        const artists = currentTrack.artists.map((artist) => artist.name);
+        const title = currentTrack.name;
+
+        return {
+            artists: artists,
+            title: title
+        }
+    } 
+
     static async handleResponseStatus(result, res) {
         res.status(result.status);
 


### PR DESCRIPTION
Improved genius results by first searching song by ISRC on spotify and using that title and artists for the search on genius.
<br>
Avoids inconsistency where KLOUD has artist name GEN.KLOUD too, and genius only gives results by searching with his more popular name GEN.KLOUD.
<br>
Musixmatch API also changed to search by ISRC. This avoids need for any sort of passes and best search checking. Simplified the process completely and BINKUSUNO SAKE vs ビンクスの酒 doesn't matter anymore as both have same ISRC code.