### PR TITLE
Handled Empty PFP Images Array

### DIFF
--- a/server/spotify/spotifyParser.js
+++ b/server/spotify/spotifyParser.js
@@ -1,16 +1,22 @@
 
 class SpotifyParser {
     static parseUserInfo(userinfo) {
+        const images = null;
+
+        if(userinfo.images.length) {
+            images = {
+                default: userinfo.images[0].url,
+                large: userinfo.images[1].url,
+            };
+        }
+
         return {
             user: {
                 id: userinfo.id,
                 displayName: userinfo.display_name,
                 url: userinfo.external_urls.spotify,
             },
-            images: {
-                default: userinfo.images[0].url,
-                large: userinfo.images[1].url,
-            },
+            images: images,
             country: userinfo.country,
             hasPremium: userinfo.product === 'premium',
         };


### PR DESCRIPTION
Now the server will return 'null' in the images field when the user does not have any pfp associated with their account.
@Kunal-JockL Please let me know if instead of null, would it be preferable to return an empty array instead.

