### PR TITLE
Podcast Support on server side.

### DIFF
--- a/server/routes/me.js
+++ b/server/routes/me.js
@@ -13,7 +13,7 @@ router.get('/info', async (req, res) => {
 });
 
 router.get('/player', async (req, res) => {
-    let playerInfo = await SpotifyAPI.Get('/me/player', req, res);
+    let playerInfo = await SpotifyAPI.Get('/me/player?additional_types=episode', req, res);
 
     if(res.statusCode === 200) {
         playerInfo = SpotifyParser.parsePlayerInfo(playerInfo);

--- a/server/spotify/spotifyParser.js
+++ b/server/spotify/spotifyParser.js
@@ -25,8 +25,6 @@ class SpotifyParser {
     }
 
     static parseTrackInfo(playerInfo) {
-        console.log(playerInfo.item);
-
         let parsed = {
             player: {
                 playing: playerInfo.is_playing,
@@ -55,8 +53,6 @@ class SpotifyParser {
     }
 
     static parseEpisodeInfo(playerInfo) {
-        console.log(playerInfo.item);
-
         let parsed = {
             player: {
                 playing: playerInfo.is_playing,
@@ -67,6 +63,8 @@ class SpotifyParser {
             itemType: playerInfo.currently_playing_type,
             item: {
                 title: playerInfo.item.name,
+                description: playerInfo.item.description,
+                language: playerInfo.item.language,
                 show: {
                     name: playerInfo.item.show.name,
                     url: playerInfo.item.show.external_urls.spotify,

--- a/server/spotify/spotifyParser.js
+++ b/server/spotify/spotifyParser.js
@@ -17,6 +17,16 @@ class SpotifyParser {
     }
 
     static parsePlayerInfo(playerInfo) {
+        if(playerInfo.currently_playing_type === 'track') {
+            return this.parseTrackInfo(playerInfo);
+        } else {
+            return this.parseEpisodeInfo(playerInfo);
+        }
+    }
+
+    static parseTrackInfo(playerInfo) {
+        console.log(playerInfo.item);
+
         let parsed = {
             player: {
                 playing: playerInfo.is_playing,
@@ -38,7 +48,36 @@ class SpotifyParser {
                 url: playerInfo.item.external_urls.spotify,
                 isrc: playerInfo.item.external_ids.isrc,
                 popularity: playerInfo.item.popularity,
-            }
+            },
+        };
+
+        return parsed;
+    }
+
+    static parseEpisodeInfo(playerInfo) {
+        console.log(playerInfo.item);
+
+        let parsed = {
+            player: {
+                playing: playerInfo.is_playing,
+                progress: playerInfo.progress_ms,
+                duration: playerInfo.item.duration_ms,
+                device: playerInfo.device.name,
+            },
+            itemType: playerInfo.currently_playing_type,
+            item: {
+                title: playerInfo.item.name,
+                show: {
+                    name: playerInfo.item.show.name,
+                    url: playerInfo.item.show.external_urls.spotify,
+                },
+                images: {
+                    default: playerInfo.item.images[1].url,
+                    large: playerInfo.item.images[0].url,
+                },
+                url: playerInfo.item.external_urls.spotify,
+                id: playerInfo.item.id,
+            },
         };
 
         return parsed;


### PR DESCRIPTION
The server now handles 'episode' type of playback.

# JSON Response for Track:
https://github.com/notvalproate/riffly/blob/ac0e2994d83289d76ed81203f81e11e96bf12e8f/server/spotify/spotifyParser.js#L28-L50
# JSON Reponse for episode:
https://github.com/notvalproate/riffly/blob/ac0e2994d83289d76ed81203f81e11e96bf12e8f/server/spotify/spotifyParser.js#L56-L79
<hr>
@Kunal-JockL Please do refer to the above. Use the property `itemType` to handle the data differently for a track vs for an episode in the front-end.