### PR TITLE
Old Lyrics Fix

### DIFF
--- a/client/src/app/home/home-components/song-player/song-player.component.ts
+++ b/client/src/app/home/home-components/song-player/song-player.component.ts
@@ -97,6 +97,10 @@ export class SongPlayerComponent implements OnInit, OnDestroy {
 
                     this.userInfoService.getLyrics(this.songCardData.currentISRC).subscribe({
                         next: (resp: any) => {
+                            if(resp.body.isrc !== this.songCardData.currentISRC) {
+                                return;
+                            }
+
                             this.lyricsData.loadingLyrics = false;
 
                             if(resp.body === null) {

--- a/server/controllers/lyrics/lyricsApi.js
+++ b/server/controllers/lyrics/lyricsApi.js
@@ -47,6 +47,7 @@ async function getFromGenius(currentTrack, isrc, res) {
             const json = {
                 provider: 'genius',
                 url: gTrack.url,
+                isrc: isrc,
                 lyricsBody: gLyrics,
             };
 
@@ -84,6 +85,7 @@ async function getFromMusixmatch(isrc, res) {
     const json = {
         provider: 'musixmatch',
         url: mTrack.track_share_url,
+        isrc: isrc,
         lyricsBody: mLyrics,
     };
 


### PR DESCRIPTION
Fixed a bug where the lyrics of the previous song would appear after changing to a new song quickly which has its lyrics cached. Fixed by adding the ISRC to the lyrics response body so that front-end can check if current ISRC matches the one in the response, and only then will set the lyrics.

> Note: Please use redisClient.flushAll() to clear the current redis cache so that it can accommodate for the new lyrics body format. Simply call this function at the beginning of the `getLyrics` function in the `LyricsAPI` and run the server once and access the site and play a song once. This will clear all the previous cache in Redis.